### PR TITLE
Update example_advanced_diffex_options.md

### DIFF
--- a/doc/example_advanced_diffex_options.md
+++ b/doc/example_advanced_diffex_options.md
@@ -50,7 +50,7 @@ diffex:
         contrasts:  # Empty contrasts triggers different behavior
         set_ref_levels:
           - treatment::control
-        DESeq:
+        DESeq2:
             design: ~ batch + treatment
             DESeq:
                 test: LRT


### PR DESCRIPTION
LRT example had `DESeq` instead of `DESeq2`.  If someone copied and pasted the code it results in an error